### PR TITLE
fixed failing test - changed default behavior when options.destLanguage ...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ Xliff2JSON.prototype._parseJSONAndDecorate = function(json,options,cb){
     if (typeof cb !== 'function'){
       throw new Error("callback must be a function");
     }
-    var language = options.destLanguage || Object.keys(json)[0];
+    var language = options.destLanguage || 'fr';
     var output={
       xliff: {
         "$": {
@@ -112,7 +112,8 @@ Xliff2JSON.prototype._parseJSONAndDecorate = function(json,options,cb){
         "file":[{
             "$": {
               "source-language": options.srcLanguage || "en",
-              "target-language": language,
+              "target-language": options.destLanguage || "fr",
+
               "datatype": options.dataType || "plaintext",
               "original": options.original || "messages",
               "product-name": options.productName || "messages"


### PR DESCRIPTION
Hi, and thanks for this repo!! 
In [this line](https://github.com/chrishokamp/xliff2json/blob/master/lib/index.js#L106), `var language` was being set to a segment value, instead of a language property, which caused a test to fail. Is there a reason for that behavior.
